### PR TITLE
Integrate `gemmology` as an 8-bit multiply backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "3rd-party/ruy"]
 	path = 3rd-party/ruy
 	url = https://github.com/google/ruy
+[submodule "3rd-party/gemmology"]
+	path = 3rd-party/gemmology
+	url = https://github.com/mozilla/gemmology.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,13 +56,8 @@ endif(WITH_RUY)
 if(WITH_GEMMOLOGY)
   set(SLIMT_COMPILE_DEFINITIONS ${SLIMT_COMPILE_DEFINITIONS}
                                 SLIMT_HAS_GEMMOLOGY)
-  if(APPLE)
-    add_library(xsimd INTERFACE)
-    target_include_directories(
-      xsimd INTERFACE "/opt/homebrew/Cellar/xsimd/11.1.0/include")
-    add_library(xsimd::xsimd ALIAS xsimd)
-    set(SLIMT_EXTERNAL_LIBS ${SLIMT_EXTERNAL_LIBS} xsimd::xsimd)
-  endif(APPLE)
+  find_package(xsimd REQUIRED)
+  set(SLIMT_EXTERNAL_LIBS ${SLIMT_EXTERNAL_LIBS} xsimd)
 endif(WITH_GEMMOLOGY)
 
 # cmake-format: off

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,14 +54,12 @@ if(WITH_RUY)
 endif(WITH_RUY)
 
 if(WITH_GEMMOLOGY)
-  set(SLIMT_COMPILE_DEFINITIONS ${SLIMT_COMPILE_DEFINITIONS} SLIMT_HAS_GEMMOLOGY)
+  set(SLIMT_COMPILE_DEFINITIONS ${SLIMT_COMPILE_DEFINITIONS}
+                                SLIMT_HAS_GEMMOLOGY)
   if(APPLE)
     add_library(xsimd INTERFACE)
     target_include_directories(
-      xsimd
-      INTERFACE
-        "/opt/homebrew/Cellar/xsimd/11.1.0/include"
-    )
+      xsimd INTERFACE "/opt/homebrew/Cellar/xsimd/11.1.0/include")
     add_library(xsimd::xsimd ALIAS xsimd)
     set(SLIMT_EXTERNAL_LIBS ${SLIMT_EXTERNAL_LIBS} xsimd::xsimd)
   endif(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SLIMT_COMPILE_DEFINITIONS "")
 
 option(WITH_INTGEMM "Use intgemm" ON)
 option(WITH_RUY "Use ruy" OFF)
+option(WITH_GEMMOLOGY "Use gemmology" OFF)
 option(WITH_BLAS "Use BLAS. Otherwise moves to ruy" ON)
 
 set(SLIMT_EXTERNAL_LIBS Sentencepiece::Sentencepiece)
@@ -51,6 +52,11 @@ if(WITH_RUY)
   set(SLIMT_COMPILE_DEFINITIONS ${SLIMT_COMPILE_DEFINITIONS} SLIMT_HAS_RUY)
   set(SLIMT_EXTERNAL_LIBS ${SLIMT_EXTERNAL_LIBS} ruy)
 endif(WITH_RUY)
+
+if(WITH_GEMMOLOGY)
+  set(SLIMT_COMPILE_DEFINITIONS ${SLIMT_COMPILE_DEFINITIONS} SLIMT_HAS_GEMMOLOGY)
+  set(SLIMT_EXTERNAL_LIBS ${SLIMT_EXTERNAL_LIBS} gemmology)
+endif(WITH_GEMMOLOGY)
 
 # cmake-format: off
 set(CMAKE_CXX_FLAGS_PROFILE           "${CMAKE_CXX_FLAGS_RELEASE} -pg" CACHE STRING "Flags used by the C++ compiler during profile builds." FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,16 @@ endif(WITH_RUY)
 
 if(WITH_GEMMOLOGY)
   set(SLIMT_COMPILE_DEFINITIONS ${SLIMT_COMPILE_DEFINITIONS} SLIMT_HAS_GEMMOLOGY)
-  set(SLIMT_EXTERNAL_LIBS ${SLIMT_EXTERNAL_LIBS} gemmology)
+  if(APPLE)
+    add_library(xsimd INTERFACE)
+    target_include_directories(
+      xsimd
+      INTERFACE
+        "/opt/homebrew/Cellar/xsimd/11.1.0/include"
+    )
+    add_library(xsimd::xsimd ALIAS xsimd)
+    set(SLIMT_EXTERNAL_LIBS ${SLIMT_EXTERNAL_LIBS} xsimd::xsimd)
+  endif(APPLE)
 endif(WITH_GEMMOLOGY)
 
 # cmake-format: off

--- a/slimt/QMM.cc
+++ b/slimt/QMM.cc
@@ -14,7 +14,10 @@
 #endif
 
 #ifdef SLIMT_HAS_GEMMOLOGY
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "3rd-party/gemmology/gemmology.h"
+#pragma GCC diagnostic pop
 #endif
 
 #include "slimt/Tensor.hh"
@@ -556,7 +559,7 @@ Tensor affine_with_select<Provider::kGemmology>(
   // Prepare Activations (A).
   Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
   gemmology::Shift::PrepareA(                                //
-      A.data<float>(), prepared_A.data<int8_t>(),            //
+      A.data<float>(), prepared_A.data<uint8_t>(),            //
       a_quant,                                               //
       A_rows, width                                          //
   );
@@ -610,7 +613,7 @@ Tensor affine_with_select<Provider::kGemmology>(
   auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
       unquant_multiplier, selected_bias.data<float>(), y.data<float>());
   gemmology::Shift::Multiply(                                //
-      prepared_A.data<int8_t>(), selected_B.data<int8_t>(),  //
+      prepared_A.data<uint8_t>(), selected_B.data<int8_t>(),  //
       A_rows, width, selected_B_cols,                        //
       multiply_callback                                      //
   );
@@ -642,7 +645,7 @@ Tensor affine<Provider::kGemmology>(Tensor& x, Tensor& W, Tensor& b,
   // Prepare Activations (A).
   Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
   gemmology::Shift::PrepareA(                                //
-      A.data<float>(), prepared_A.data<int8_t>(),            //
+      A.data<float>(), prepared_A.data<uint8_t>(),            //
       a_quant,                                               //
       A_rows, width                                          //
   );
@@ -677,7 +680,7 @@ Tensor affine<Provider::kGemmology>(Tensor& x, Tensor& W, Tensor& b,
   auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
       unquant_multiplier, prepared_bias.data<float>(), y.data<float>());
   gemmology::Shift::Multiply(                       //
-      prepared_A.data<int8_t>(), B.data<int8_t>(),  //
+      prepared_A.data<uint8_t>(), B.data<int8_t>(),  //
       A_rows, width, B_cols,                        //
       multiply_callback                             //
   );
@@ -707,7 +710,7 @@ Tensor dot<Provider::kGemmology>(Tensor& x, Tensor& W, float a_quant,
   // Prepare Activations (A).
   Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
   gemmology::Shift::PrepareA(                                //
-      A.data<float>(), prepared_A.data<int8_t>(),            //
+      A.data<float>(), prepared_A.data<uint8_t>(),            //
       a_quant,                                               //
       A_rows, width                                          //
   );
@@ -748,7 +751,7 @@ Tensor dot<Provider::kGemmology>(Tensor& x, Tensor& W, float a_quant,
   auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
       unquant_multiplier, prepared_bias.data<float>(), y.data<float>());
   gemmology::Shift::Multiply(                       //
-      prepared_A.data<int8_t>(), B.data<int8_t>(),  //
+      prepared_A.data<uint8_t>(), B.data<int8_t>(),  //
       A_rows, width, B_cols,                        //
       multiply_callback                             //
   );

--- a/slimt/QMM.cc
+++ b/slimt/QMM.cc
@@ -559,7 +559,7 @@ Tensor affine_with_select<Provider::kGemmology>(
   // Prepare Activations (A).
   Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
   gemmology::Shift::PrepareA(                                //
-      A.data<float>(), prepared_A.data<uint8_t>(),            //
+      A.data<float>(), prepared_A.data<uint8_t>(),           //
       a_quant,                                               //
       A_rows, width                                          //
   );
@@ -612,10 +612,10 @@ Tensor affine_with_select<Provider::kGemmology>(
   float unquant_multiplier = 1.0F / (a_quant * b_quant);
   auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
       unquant_multiplier, selected_bias.data<float>(), y.data<float>());
-  gemmology::Shift::Multiply(                                //
+  gemmology::Shift::Multiply(                                 //
       prepared_A.data<uint8_t>(), selected_B.data<int8_t>(),  //
-      A_rows, width, selected_B_cols,                        //
-      multiply_callback                                      //
+      A_rows, width, selected_B_cols,                         //
+      multiply_callback                                       //
   );
 
   return y;
@@ -645,7 +645,7 @@ Tensor affine<Provider::kGemmology>(Tensor& x, Tensor& W, Tensor& b,
   // Prepare Activations (A).
   Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
   gemmology::Shift::PrepareA(                                //
-      A.data<float>(), prepared_A.data<uint8_t>(),            //
+      A.data<float>(), prepared_A.data<uint8_t>(),           //
       a_quant,                                               //
       A_rows, width                                          //
   );
@@ -679,10 +679,10 @@ Tensor affine<Provider::kGemmology>(Tensor& x, Tensor& W, Tensor& b,
   float unquant_multiplier = 1.0F / (a_quant * b_quant);
   auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
       unquant_multiplier, prepared_bias.data<float>(), y.data<float>());
-  gemmology::Shift::Multiply(                       //
+  gemmology::Shift::Multiply(                        //
       prepared_A.data<uint8_t>(), B.data<int8_t>(),  //
-      A_rows, width, B_cols,                        //
-      multiply_callback                             //
+      A_rows, width, B_cols,                         //
+      multiply_callback                              //
   );
 
   return y;
@@ -710,7 +710,7 @@ Tensor dot<Provider::kGemmology>(Tensor& x, Tensor& W, float a_quant,
   // Prepare Activations (A).
   Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
   gemmology::Shift::PrepareA(                                //
-      A.data<float>(), prepared_A.data<uint8_t>(),            //
+      A.data<float>(), prepared_A.data<uint8_t>(),           //
       a_quant,                                               //
       A_rows, width                                          //
   );
@@ -750,10 +750,10 @@ Tensor dot<Provider::kGemmology>(Tensor& x, Tensor& W, float a_quant,
   float unquant_multiplier = 1.0F / (a_quant * b_quant);
   auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
       unquant_multiplier, prepared_bias.data<float>(), y.data<float>());
-  gemmology::Shift::Multiply(                       //
+  gemmology::Shift::Multiply(                        //
       prepared_A.data<uint8_t>(), B.data<int8_t>(),  //
-      A_rows, width, B_cols,                        //
-      multiply_callback                             //
+      A_rows, width, B_cols,                         //
+      multiply_callback                              //
   );
 
   return y;

--- a/slimt/QMM.cc
+++ b/slimt/QMM.cc
@@ -13,6 +13,10 @@
 #include "3rd-party/ruy/ruy/ruy.h"
 #endif
 
+#ifdef SLIMT_HAS_GEMMOLOGY
+#include "3rd-party/gemmology/gemmology.h"
+#endif
+
 #include "slimt/Tensor.hh"
 
 namespace slimt::qmm {
@@ -526,6 +530,249 @@ void PrepareBQuantizedTransposed<Provider::kRuy>(const int8_t* input,
   std::memcpy(output, input,
               /*count=*/sizeof(int8_t) * (rows * cols));
 }
+#endif
+
+#ifdef SLIMT_HAS_GEMMOLOGY
+template <>
+Tensor affine_with_select<Provider::kGemmology>(
+    Tensor& x, Tensor& W, Tensor& b, float a_quant, float b_quant,
+    const std::vector<uint32_t>& indices, const std::string& name) {
+  // Naming is to simplify thinking with the gemmology API below.
+  Tensor& A = x;  // NOLINT
+  Tensor& B = W;  // NOLINT
+  Tensor& bias = b;
+
+  size_t A_cols = A.dim(-1);          // NOLINT
+  size_t B_cols = B.dim(-1);          // NOLINT
+  size_t A_rows = A.size() / A_cols;  // NOLINT
+  size_t B_rows = B.size() / B_cols;  // NOLINT
+
+  size_t width = A_cols;
+  // SLIMT_TRACE3(x.shape(), W.shape(), b.shape());
+
+  // Check widths are same, making matrix multiplication viable.
+  assert(A_cols == B_rows);
+
+  // Prepare Activations (A).
+  Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
+  gemmology::Shift::PrepareA(                                //
+      A.data<float>(), prepared_A.data<int8_t>(),            //
+      a_quant,                                               //
+      A_rows, width                                          //
+  );
+
+  // Prepare bias
+  Tensor prepared_bias(Type::f32, bias.shape(), "prepared_bias");
+  constexpr float kMax8bit = 127.0F;
+  float a_alpha = kMax8bit / a_quant;
+  float b_alpha = kMax8bit / b_quant;
+
+  float bias_unquant_multiplier = (-1.0F * (a_alpha * b_alpha)) / kMax8bit;
+  auto prepare_bias_callback =
+      gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
+          bias_unquant_multiplier, bias.data<float>(),  //
+          prepared_bias.data<float>()                   //
+      );
+
+  gemmology::Shift::PrepareBias(  //
+      B.data<int8_t>(),           //
+      width, B_cols,              //
+      prepare_bias_callback       //
+  );
+
+  // Select before multiply?
+  // NOLINTNEXTLINE
+  Tensor selected_B(Type::i8, Shape({width, indices.size()}), "selected_B");
+  const uint32_t* indices_begin = indices.data();
+  const uint32_t* indices_end = indices.data() + indices.size();
+
+  gemmology::SelectColumnsB(B.data<int8_t>(), selected_B.data<int8_t>(), B_rows,
+                            indices_begin, indices_end);
+
+  // Select bias accordingly.
+  Tensor selected_bias(Type::f32, Shape({indices.size()}), "selected_bias");
+  auto* selected_bias_ptr = selected_bias.data<float>();
+  for (uint32_t index : indices) {
+    *(selected_bias_ptr) = *(prepared_bias.data<float>() + index);
+    ++selected_bias_ptr;
+  }
+
+  // Multiply y = A * B + bias (affine)
+  // Set y's shape replacing last dimension with the feature-dim B is projecting
+  // onto (B_cols).
+  Shape out_shape = x.shape();
+  out_shape.set_dim(-1, indices.size());
+
+  Tensor y(Type::f32, out_shape, (name.empty() ? x.name() : name));
+  size_t selected_B_cols = selected_B.dim(-1);  // NOLINT
+
+  float unquant_multiplier = 1.0F / (a_quant * b_quant);
+  auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
+      unquant_multiplier, selected_bias.data<float>(), y.data<float>());
+  gemmology::Shift::Multiply(                                //
+      prepared_A.data<int8_t>(), selected_B.data<int8_t>(),  //
+      A_rows, width, selected_B_cols,                        //
+      multiply_callback                                      //
+  );
+
+  return y;
+}
+
+template <>
+Tensor affine<Provider::kGemmology>(Tensor& x, Tensor& W, Tensor& b,
+                                    float a_quant, float b_quant,
+                                    const std::string& name) {
+  // Naming is to simplify thinking with the gemmology API below.
+  Tensor& A = x;  // NOLINT
+  Tensor& B = W;  // NOLINT
+  Tensor& bias = b;
+
+  size_t A_cols = A.dim(-1);          // NOLINT
+  size_t B_cols = B.dim(-1);          // NOLINT
+  size_t A_rows = A.size() / A_cols;  // NOLINT
+  size_t B_rows = B.size() / B_cols;  // NOLINT
+
+  size_t width = A_cols;
+  // SLIMT_TRACE3(x.shape(), W.shape(), b.shape());
+
+  // Check widths are same, making matrix multiplication viable.
+  (void)B_rows;
+  assert(A_cols == B_rows);
+
+  // Prepare Activations (A).
+  Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
+  gemmology::Shift::PrepareA(                                //
+      A.data<float>(), prepared_A.data<int8_t>(),            //
+      a_quant,                                               //
+      A_rows, width                                          //
+  );
+
+  // Prepare bias
+  Tensor prepared_bias(Type::f32, bias.shape(), "prepared_bias");
+  float a_alpha = 127.0F / a_quant;
+  float b_alpha = 127.0F / b_quant;
+
+  float bias_unquant_multiplier = (-1.0F * (a_alpha * b_alpha)) / 127.0F;
+  auto prepare_bias_callback =
+      gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
+          bias_unquant_multiplier, bias.data<float>(),  //
+          prepared_bias.data<float>()                   //
+      );
+
+  gemmology::Shift::PrepareBias(  //
+      B.data<int8_t>(),           //
+      width, B_cols,              //
+      prepare_bias_callback       //
+  );
+
+  // Multiply y = A * B + bias (affine)
+  // Set y's shape replacing last dimension with the feature-dim B is projecting
+  // onto (B_cols).
+  Shape out_shape = x.shape();
+  out_shape.set_dim(-1, B_cols);
+
+  Tensor y(Type::f32, out_shape, (name.empty() ? x.name() : name));
+
+  float unquant_multiplier = 1.0F / (a_quant * b_quant);
+  auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
+      unquant_multiplier, prepared_bias.data<float>(), y.data<float>());
+  gemmology::Shift::Multiply(                       //
+      prepared_A.data<int8_t>(), B.data<int8_t>(),  //
+      A_rows, width, B_cols,                        //
+      multiply_callback                             //
+  );
+
+  return y;
+}
+
+template <>
+Tensor dot<Provider::kGemmology>(Tensor& x, Tensor& W, float a_quant,
+                                 float b_quant, const std::string& name) {
+  // Naming is to simplify thinking with the gemmology API below.
+  Tensor& A = x;  // NOLINT
+  Tensor& B = W;  // NOLINT
+
+  size_t A_cols = A.dim(-1);          // NOLINT
+  size_t B_cols = B.dim(-1);          // NOLINT
+  size_t A_rows = A.size() / A_cols;  // NOLINT
+  size_t B_rows = B.size() / B_cols;  // NOLINT
+
+  size_t width = A_cols;
+  // SLIMT_TRACE3(x.shape(), W.shape(), b.shape());
+
+  // Check widths are same, making matrix multiplication viable.
+  (void)B_rows;
+  assert(A_cols == B_rows);
+
+  // Prepare Activations (A).
+  Tensor prepared_A(Type::i8, A.shape(), "quantized_acts");  // NOLINT
+  gemmology::Shift::PrepareA(                                //
+      A.data<float>(), prepared_A.data<int8_t>(),            //
+      a_quant,                                               //
+      A_rows, width                                          //
+  );
+
+  // Prepare bias
+
+  // Fake bias, all elements are zero.
+  Tensor bias(x.type(), Shape({1, B_cols}), "zero_bias");
+  bias.fill_in_place(0.0F);
+
+  Tensor prepared_bias(Type::f32, bias.shape(), "prepared_bias");
+  float a_alpha = 127.0F / a_quant;
+  float b_alpha = 127.0F / b_quant;
+
+  float bias_unquant_multiplier = (-1.0F * (a_alpha * b_alpha)) / 127.0F;
+  auto prepare_bias_callback =
+      gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
+          bias_unquant_multiplier, bias.data<float>(),  //
+          prepared_bias.data<float>()                   //
+      );
+
+  gemmology::Shift::PrepareBias(  //
+      B.data<int8_t>(),           //
+      width, B_cols,              //
+      prepare_bias_callback       //
+  );
+
+  //
+  // Multiply y = A * B  (dot)
+  // Set y's shape replacing last dimension with the feature-dim B is projecting
+  // onto (B_cols).
+  Shape out_shape = x.shape();
+  out_shape.set_dim(-1, B_cols);
+
+  Tensor y(Type::f32, out_shape, (name.empty() ? x.name() : name));
+
+  float unquant_multiplier = 1.0F / (a_quant * b_quant);
+  auto multiply_callback = gemmology::callbacks::UnquantizeAndAddBiasAndWrite(
+      unquant_multiplier, prepared_bias.data<float>(), y.data<float>());
+  gemmology::Shift::Multiply(                       //
+      prepared_A.data<int8_t>(), B.data<int8_t>(),  //
+      A_rows, width, B_cols,                        //
+      multiply_callback                             //
+  );
+
+  return y;
+}
+
+template <>
+void PrepareBTransposed<Provider::kGemmology>(const float* weights,
+                                              int8_t* prepared,
+                                              float quantization_multiplier,
+                                              size_t cols, size_t rows) {
+  gemmology::PrepareBTransposed(weights, prepared, quantization_multiplier,
+                                cols, rows);
+}
+
+template <>
+void PrepareBQuantizedTransposed<Provider::kGemmology>(const int8_t* input,
+                                                       int8_t* output,
+                                                       size_t rows,
+                                                       size_t cols) {
+  gemmology::PrepareBQuantizedTransposed(input, output, rows, cols);
+}
+
 #endif
 
 }  // namespace detail

--- a/slimt/QMM.hh
+++ b/slimt/QMM.hh
@@ -10,9 +10,10 @@ namespace slimt::qmm {
 namespace detail {
 
 enum class Provider {
-  kNone,     //
-  kIntgemm,  //
-  kRuy       //
+  kNone,      //
+  kIntgemm,   //
+  kRuy,       //
+  kGemmology  //
 };
 
 template <enum Provider>
@@ -42,6 +43,10 @@ constexpr Provider kAutoProvider = Provider::kIntgemm;
 
 #ifdef SLIMT_HAS_RUY
 constexpr Provider kAutoProvider = Provider::kRuy;
+#endif
+
+#ifdef SLIMT_HAS_GEMMOLOGY
+constexpr Provider kAutoProvider = Provider::kGemmology;
 #endif
 }  // namespace detail
 


### PR DESCRIPTION
Integrate [gemmology](https://github.com/mozilla/gemmology) as a possible alternate backend. 
Gemmology requires [xsimd](https://github.com/xtensor-stack/xsimd) which currently is not in the list of the 3rd-party libraries.