### PR TITLE
Create RNN states dynamically

### DIFF
--- a/slimt/Model.hh
+++ b/slimt/Model.hh
@@ -19,12 +19,13 @@ class Decoder {
   Sentences decode(Tensor &encoder_out, Tensor &mask, const Words &source);
 
  private:
-  Tensor step(Tensor &encoder_out, Tensor &mask, Words &previous_step);
+  Tensor step(Tensor &encoder_out, Tensor &mask, std::vector<Tensor> &states,
+              Words &previous_step);
 
   static Words greedy_sample(Tensor &logits, const Words &words,
                              size_t batch_size);
 
-  void set_start_state(size_t batch_size);
+  std::vector<Tensor> start_states(size_t batch_size);
 
   Vocabulary &vocabulary_;
 

--- a/slimt/Modules.hh
+++ b/slimt/Modules.hh
@@ -45,11 +45,10 @@ class SSRU {
  public:
   explicit SSRU() = default;
   void register_parameters(const std::string &prefix, ParameterMap &parameters);
-  Tensor forward(Tensor &x);
-  void set_start_state(size_t batch_size);
+  Tensor forward(Tensor &state, Tensor &x);
+  Tensor start_state(size_t batch_size);
 
  private:
-  Tensor state_;
   Affine F_;
   Linear O_;
   LayerNorm ln_;
@@ -84,8 +83,8 @@ class DecoderLayer {
   explicit DecoderLayer(size_t depth, size_t ffn_count);
   void register_parameters(const std::string &prefix, ParameterMap &parameters);
   std::tuple<Tensor, Tensor> forward(Tensor &encoder_out, Tensor &mask,
-                                     Tensor &x);
-  void set_start_state(size_t batch_size) { rnn_.set_start_state(batch_size); }
+                                     Tensor &state, Tensor &x);
+  Tensor start_state(size_t batch_size) { return rnn_.start_state(batch_size); }
 
  private:
   size_t depth_;


### PR DESCRIPTION
The SSRU had states that were modified during a loop across time-steps
statefully. This PR changes these to be created dynamically during each 
call. The objective is to not have race-conditions when the same model
is used by multiple worker threads in a multi-threaded translation setting.