### PR TITLE
Upgrade to LLVM-17 linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,14 +32,23 @@ jobs:
           run: |
             sudo apt-get update
             sudo apt-get install -y build-essential cmake
-            sudo apt-get install -y clang-format clang-tidy
             python3 -m pip install black isort
             python3 -m pip install cmake-format
             sudo apt-get install -y shfmt
 
+        - name: Setup latest clang
+          run: |
+           sudo bash scripts/ci/update-alternatives-clang.sh 17 100
+
         - name: Run format-script
           run:
             bash scripts/ci/format-check.sh
+
+        - uses: actions/upload-artifact@v2
+          if: always()
+          with:
+            name: format
+            path: ${{ github.workspace }}/build/clang-tidy.*.yml
 
   build-test:
       name: "build-test"

--- a/app/main.cc
+++ b/app/main.cc
@@ -1,9 +1,16 @@
-#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+#include <future>
 #include <iostream>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include "3rd-party/CLI11.hpp"
-#include "slimt/slimt.hh"
+#include "slimt/Frontend.hh"
+#include "slimt/Model.hh"
+#include "slimt/Response.hh"
 
 inline std::string read_from_stdin() {
   // Read a large input text blob from stdin

--- a/scripts/ci/format-check.sh
+++ b/scripts/ci/format-check.sh
@@ -11,14 +11,20 @@ function slimt-check-clang-format {
 function slimt-check-clang-tidy {
   # clang-tidy
   mkdir -p build
-  pushd build
-  cmake \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
-    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
-    ..
-  popd
-  run-clang-tidy -p build -header-filter="$PWD/slimt" "$PWD/slimt/.*"
-  run-clang-tidy -p build -header-filter="$PWD/slimt" "$PWD/app/.*"
+  ARGS=(
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+    -DUSE_BUILTIN_SENTENCEPIECE=ON
+    -DWITH_INTGEMM=ON -DUSE_AVX2=ON -DUSE_SSE2=ON
+
+    # Gemmology, which is default on has to be turned off.
+    -DWITH_GEMMOLOGY=OFF
+    -DEXPORT_CMAKE_FILE=OFF
+  )
+
+  cmake -B build -S . "${ARGS[@]}"
+  run-clang-tidy -export-fixes build/clang-tidy.slimt.yml -p build -header-filter="$PWD/slimt" "$PWD/slimt/.*"
+  run-clang-tidy -export-fixes build/clang-tidy.app.yml -p build -header-filter="$PWD/slimt" "$PWD/app/.*"
 
 }
 

--- a/scripts/ci/update-alternatives-clang.sh
+++ b/scripts/ci/update-alternatives-clang.sh
@@ -1,0 +1,69 @@
+# !/bin/bash
+#
+# Taken from comment inside the following gist
+# https://gist.github.com/junkdog/70231d6953592cd6f27def59fe19e50d?permalink_comment_id=4336074#gistcomment-4336074
+# add clang ${version} to Ubuntu
+
+set -eo pipefail
+
+update_alternatives() {
+  local version=${1}
+  local priority=${2}
+  local master=${3}
+  local slaves=${4}
+  local path=${5}
+  local cmdln
+
+  cmdln="--verbose --install ${path}${master} ${master} ${path}${master}-${version} ${priority}"
+  for slave in ${slaves}; do
+    cmdln="${cmdln} --slave ${path}${slave} ${slave} ${path}${slave}-${version}"
+  done
+  sudo update-alternatives ${cmdln}
+  sudo update-alternatives --set ${master} ${path}${master}-${version}
+}
+
+update_alternatives_master() {
+  local version=${1}
+  local priority=${2}
+  local packages=${3}
+  local path=${4}
+  local cmdln
+  for package in ${packages}; do
+    cmdln="--verbose --install ${path}${package} ${package} ${path}${package}-${version} ${priority}"
+    sudo update-alternatives ${cmdln}
+    sudo update-alternatives --set ${package} ${path}${package}-${version}
+  done
+}
+
+if [[ ${#} -ne 2 ]]; then
+  echo usage: "${0}" clang_version priority
+  exit 1
+fi
+
+version=${1}
+priority=${2}
+path="/usr/bin/"
+
+sudo apt update
+
+# download and launch the setup script
+wget https://apt.llvm.org/llvm.sh
+# sudo bash llvm.sh ${version}
+sudo bash llvm.sh ${version} all
+
+master="clang"
+slaves="asan_symbolize bugpoint clang-cpp clangd count dsymutil FileCheck ld64.lld ld.lld llc lld lldb lldb-argdumper lldb-instr lldb-server lldb-vscode lld-link lli lli-child-target not obj2yaml opt sanstats split-file UnicodeNameMappingGenerator verify-uselis
+torder wasm-ld yaml2obj yaml-bench"
+update_alternatives "${version}" "${priority}" "${master}" "${slaves}" "${path}"
+
+packages="clang++ clang-tidy run-clang-tidy"
+update_alternatives_master "${version}" "${priority}" "${packages}" "${path}"
+
+# configure with update-alternatives
+master="llvm-config"
+slaves="llvm-addr2line llvm-ar llvm-as llvm-bcanalyzer llvm-bitcode-strip llvm-cat llvm-cfi-verify llvm-cov llvm-c-test llvm-cvtres llvm-cxxdump llvm-cxxfilt llvm-cxxmap llvm-debuginfo-analyzer llvm-debuginfod llvm-debuginfod-find llvm-diff llvm-dis llvm-dlltool llvm-d
+warfdump llvm-dwarfutil llvm-dwp llvm-exegesis llvm-extract llvm-gsymutil llvm-ifs llvm-install-name-tool llvm-jitlink llvm-jitlink-executor llvm-lib llvm-libtool-darwin llvm-link llvm-lipo llvm-lto llvm-lto2 llvm-mc llvm-mca llvm-ml llvm-modextract llvm-mt llvm-nm llv
+m-objcopy llvm-objdump llvm-opt-report llvm-otool llvm-pdbutil llvm-PerfectShuffle llvm-profdata llvm-profgen llvm-ranlib llvm-rc llvm-readelf llvm-readobj llvm-reduce llvm-remark-size-diff llvm-remarkutil llvm-rtdyld llvm-sim llvm-size llvm-split llvm-stress llvm-stri
+ngs llvm-strip llvm-symbolizer llvm-tapi-diff llvm-tblgen llvm-tli-checker llvm-undname llvm-windres llvm-xray"
+
+update_alternatives "${version}" "${priority}" "${master}" "${slaves}" "${path}"

--- a/slimt/Aligned.cc
+++ b/slimt/Aligned.cc
@@ -1,6 +1,8 @@
 #include "slimt/Aligned.hh"
 
 #include <cassert>
+#include <cstddef>
+#include <cstdlib>
 
 namespace slimt {
 

--- a/slimt/Annotation.cc
+++ b/slimt/Annotation.cc
@@ -3,7 +3,9 @@
 #include <cassert>
 #include <cstddef>
 #include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 namespace slimt {
 

--- a/slimt/Batcher.cc
+++ b/slimt/Batcher.cc
@@ -2,12 +2,16 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <tuple>
 #include <utility>
 
 #include "slimt/Macros.hh"
 #include "slimt/Model.hh"
 #include "slimt/Request.hh"
-#include "slimt/Utils.hh"
+#include "slimt/Types.hh"
 
 namespace slimt {
 

--- a/slimt/Batcher.hh
+++ b/slimt/Batcher.hh
@@ -6,6 +6,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/slimt/Frontend.hh
+++ b/slimt/Frontend.hh
@@ -3,6 +3,7 @@
 #include <future>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "slimt/Batcher.hh"
@@ -14,6 +15,8 @@
 namespace slimt {
 
 class Model;
+struct Options;
+struct Response;
 
 struct SLIMT_EXPORT Config {
   // NOLINTBEGIN

--- a/slimt/HTML.cc
+++ b/slimt/HTML.cc
@@ -3,10 +3,16 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
-#include <compare>
+#include <cstddef>
 #include <iterator>
+#include <ostream>
 #include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
+#include "slimt/Annotation.hh"
 #include "slimt/Macros.hh"
 #include "slimt/Response.hh"
 #include "slimt/Types.hh"
@@ -386,7 +392,8 @@ HTML::HTML(std::string &source, Options &&options)
   bool add_word_break = false;  // whether to add a word break next text segment
 
   // Starting point: an empty span with no open tags.
-  spans_.push_back(Span{0, 0, {}});
+  Span start{.begin = 0, .end = 0, .tags = {}};
+  spans_.push_back(std::move(start));
 
   bool stop = false;
   while (!stop) {

--- a/slimt/Input.cc
+++ b/slimt/Input.cc
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
 
 #include "slimt/Tensor.hh"
 

--- a/slimt/Io.cc
+++ b/slimt/Io.cc
@@ -3,17 +3,21 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "slimt/Aligned.hh"
 #include "slimt/QMM.hh"
 #include "slimt/Tensor.hh"
+#include "slimt/Types.hh"
 
 namespace slimt::io {
 

--- a/slimt/Io.hh
+++ b/slimt/Io.hh
@@ -12,6 +12,7 @@
 
 #include "slimt/Aligned.hh"
 #include "slimt/Tensor.hh"
+#include "slimt/Types.hh"
 
 namespace slimt {
 

--- a/slimt/Macros.hh
+++ b/slimt/Macros.hh
@@ -3,19 +3,19 @@
 
 #define SLIMT_BREAK std::raise(SIGTRAP)
 
-#define SLIMT_TRACE(x)                                              \
-  do {                                                              \
-    std::cerr << __FILE__ << ":" << __LINE__;                       \
-    std::cerr << " " << __FUNCTION__ << " ";                        \
-    std::cerr << #x << ": " << std::scientific << (x) << std::endl; \
+#define SLIMT_TRACE(x)                                         \
+  do {                                                         \
+    std::cerr << __FILE__ << ":" << __LINE__;                  \
+    std::cerr << " " << __FUNCTION__ << " ";                   \
+    std::cerr << #x << ": " << std::scientific << (x) << '\n'; \
   } while (0)
 
-#define SLIMT_TRACE_BLOCK(x)                                        \
-  do {                                                              \
-    std::cerr << __FILE__ << ":" << __LINE__;                       \
-    std::cerr << " " << __FUNCTION__ << " \n\n";                    \
-    std::cerr << #x << ": " << std::scientific << (x) << std::endl; \
-    std::cerr << "\n\n";                                            \
+#define SLIMT_TRACE_BLOCK(x)                                   \
+  do {                                                         \
+    std::cerr << __FILE__ << ":" << __LINE__;                  \
+    std::cerr << " " << __FUNCTION__ << " \n\n";               \
+    std::cerr << #x << ": " << std::scientific << (x) << '\n'; \
+    std::cerr << "\n\n";                                       \
   } while (0);
 
 #define SLIMT_TRACE2(x, y) \

--- a/slimt/Model.cc
+++ b/slimt/Model.cc
@@ -1,14 +1,21 @@
 #include "slimt/Model.hh"
 
-#include <cmath>
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
-#include <iostream>
-#include <unordered_map>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
+#include "slimt/Aligned.hh"
 #include "slimt/Input.hh"
-#include "slimt/Modules.hh"
+#include "slimt/Io.hh"
+#include "slimt/Shortlist.hh"
+#include "slimt/Tensor.hh"
 #include "slimt/TensorOps.hh"
+#include "slimt/Transformer.hh"
+#include "slimt/Types.hh"
 #include "slimt/Vocabulary.hh"
 
 namespace slimt {

--- a/slimt/Model.hh
+++ b/slimt/Model.hh
@@ -8,6 +8,7 @@
 
 #include "slimt/Annotation.hh"
 #include "slimt/Export.hh"
+#include "slimt/Io.hh"
 #include "slimt/Shortlist.hh"
 #include "slimt/TextProcessor.hh"
 #include "slimt/Transformer.hh"
@@ -17,6 +18,7 @@
 namespace slimt {
 
 class Input;
+class Tensor;
 
 template <class Field>
 struct Package {

--- a/slimt/Modules.cc
+++ b/slimt/Modules.cc
@@ -2,9 +2,15 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <tuple>
 #include <utility>
+#include <vector>
 
 #include "slimt/QMM.hh"
+#include "slimt/Tensor.hh"
 #include "slimt/TensorOps.hh"
 
 namespace slimt {

--- a/slimt/QMM.cc
+++ b/slimt/QMM.cc
@@ -1,11 +1,12 @@
 #include "slimt/QMM.hh"
 
-#include <cassert>
-#include <cmath>
-
 #ifdef SLIMT_HAS_INTGEMM
-#include "intgemm/callbacks/configs.h"
-#include "intgemm/intgemm.h"
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "slimt/Tensor.hh"
 
 namespace slimt::qmm::detail {
 constexpr Provider kAutoProvider = Provider::Intgemm;
@@ -15,7 +16,7 @@ constexpr Provider kAutoProvider = Provider::Intgemm;
 #endif
 
 #ifdef SLIMT_HAS_RUY
-#include "ruy/ruy.h"
+
 namespace slimt::qmm::detail {
 constexpr Provider kAutoProvider = Provider::Ruy;
 }
@@ -24,18 +25,12 @@ constexpr Provider kAutoProvider = Provider::Ruy;
 #endif
 
 #ifdef SLIMT_HAS_GEMMOLOGY
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#include "gemmology/gemmology.h"
+
 namespace slimt::qmm::detail {
 constexpr Provider kAutoProvider = Provider::Gemmology;
 }
 // NOLINTNEXTLINE: The C++ file inclusion is intended.
 #include "slimt/qmm/Gemmology.inl.cc"
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef SLIMT_HAS_GEMMOLOGY
 #endif
 
 namespace slimt::qmm {

--- a/slimt/Regex.cc
+++ b/slimt/Regex.cc
@@ -1,6 +1,13 @@
 #include "slimt/Regex.hh"
 
+#include <pcre2.h>
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <sstream>
+#include <string>
+#include <string_view>
 
 namespace slimt {
 

--- a/slimt/Regex.hh
+++ b/slimt/Regex.hh
@@ -5,6 +5,9 @@
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
 
+#include <cstddef>
+#include <cstdint>
+
 namespace slimt {
 
 // Inspired by https://github.com/luvit/pcre2/blob/master/src/pcre2demo.c

--- a/slimt/Request.cc
+++ b/slimt/Request.cc
@@ -1,11 +1,12 @@
 #include "slimt/Request.hh"
 
-#include <algorithm>
-#include <compare>
+#include <cstddef>
+#include <optional>
 #include <utility>
+#include <vector>
 
 #include "slimt/Cache.hh"
-#include "slimt/Macros.hh"
+#include "slimt/ResponseBuilder.hh"
 #include "slimt/Types.hh"
 #include "slimt/Utils.hh"
 

--- a/slimt/Response.cc
+++ b/slimt/Response.cc
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <utility>
+#include <vector>
 
 #include "slimt/Annotation.hh"
 #include "slimt/Types.hh"

--- a/slimt/ResponseBuilder.cc
+++ b/slimt/ResponseBuilder.cc
@@ -1,13 +1,14 @@
 #include "slimt/ResponseBuilder.hh"
 
 #include <cstddef>
-#include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "slimt/Macros.hh"
 #include "slimt/Response.hh"
+#include "slimt/Types.hh"
 #include "slimt/Vocabulary.hh"
 
 namespace slimt {

--- a/slimt/Shortlist.cc
+++ b/slimt/Shortlist.cc
@@ -1,6 +1,12 @@
 #include "slimt/Shortlist.hh"
 
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
 #include "slimt/Macros.hh"
+#include "slimt/Types.hh"
 #include "slimt/Utils.hh"
 #include "slimt/Vocabulary.hh"
 

--- a/slimt/Splitter.cc
+++ b/slimt/Splitter.cc
@@ -1,9 +1,10 @@
-#include <cassert>
-#include <cstdio>
+#include <cstddef>
 #include <fstream>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>

--- a/slimt/Splitter.hh
+++ b/slimt/Splitter.hh
@@ -1,8 +1,14 @@
 #pragma once
+#include <stddef.h>
+
+#include <functional>
+#include <iosfwd>
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
+#include <utility>
 
 namespace slimt {
 

--- a/slimt/Tensor.cc
+++ b/slimt/Tensor.cc
@@ -1,14 +1,20 @@
 #include "slimt/Tensor.hh"
 
+#include <algorithm>
 #include <bitset>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <limits>
+#include <string>
 #include <utility>
+#include <vector>
 
+#include "slimt/Aligned.hh"
 #include "slimt/Macros.hh"
 #include "slimt/TensorOps.hh"
+#include "slimt/Types.hh"
 #include "slimt/Utils.hh"
 
 namespace slimt {

--- a/slimt/TensorOps.cc
+++ b/slimt/TensorOps.cc
@@ -1,5 +1,11 @@
 #include "slimt/TensorOps.hh"
 
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "slimt/Tensor.hh"
+
 #ifdef SLIMT_HAS_BLAS
 
 #ifdef __cplusplus
@@ -21,8 +27,6 @@ extern "C" {
 #include <cmath>
 #include <limits>
 #include <utility>
-
-#include "slimt/Simd.hh"
 
 namespace slimt {
 

--- a/slimt/TextProcessor.cc
+++ b/slimt/TextProcessor.cc
@@ -1,8 +1,11 @@
 #include "slimt/TextProcessor.hh"
 
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
 #include <string>
+#include <string_view>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -10,6 +13,7 @@
 #include "slimt/Annotation.hh"
 #include "slimt/Macros.hh"
 #include "slimt/Splitter.hh"
+#include "slimt/Types.hh"
 #include "slimt/Vocabulary.hh"
 
 namespace slimt {

--- a/slimt/Transformer.cc
+++ b/slimt/Transformer.cc
@@ -1,9 +1,19 @@
 #include "slimt/Transformer.hh"
 
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include "slimt/Io.hh"
+#include "slimt/Modules.hh"
+#include "slimt/Tensor.hh"
 #include "slimt/TensorOps.hh"
+#include "slimt/Types.hh"
 
 namespace slimt {
 

--- a/slimt/Transformer.hh
+++ b/slimt/Transformer.hh
@@ -1,7 +1,13 @@
 #pragma once
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <vector>
+
 #include "slimt/Io.hh"
 #include "slimt/Modules.hh"
 #include "slimt/Tensor.hh"
+#include "slimt/Types.hh"
 
 namespace slimt {
 

--- a/slimt/Utils.cc
+++ b/slimt/Utils.cc
@@ -3,13 +3,14 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <csignal>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
 #include <iostream>
 #include <stdexcept>
+#include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -154,7 +155,7 @@ std::tuple<Tensor, float> quantized_tensor_from_file(const std::string &fpath,
   };
 
   if (!file_exists(fpath)) {
-    std::cerr << "File " << fpath << " not found on disk." << std::endl;
+    std::cerr << "File " << fpath << " not found on disk." << '\n';
   }
 
   io::MmapFile file(fpath);
@@ -187,7 +188,7 @@ Tensor tensor_from_file(const std::string &fpath, const Shape &shape,
   };
 
   if (!file_exists(fpath)) {
-    std::cerr << "File " << fpath << " not found on disk." << std::endl;
+    std::cerr << "File " << fpath << " not found on disk." << '\n';
   }
 
   io::MmapFile file(fpath);

--- a/slimt/Utils.hh
+++ b/slimt/Utils.hh
@@ -15,6 +15,7 @@
 namespace slimt {
 
 class Tensor;
+
 class Shape;
 
 std::string checked_fpath();

--- a/slimt/Vocabulary.cc
+++ b/slimt/Vocabulary.cc
@@ -1,14 +1,22 @@
 #include "slimt/Vocabulary.hh"
 
+#include <sentencepiece_processor.h>
+
+#include <cstddef>
 #include <cstdint>
+#include <string>
 #include <string_view>
+#include <tuple>
 #include <utility>
 #include <vector>
+
+#include "slimt/Types.hh"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "sentencepiece.pb.h"
+
 #pragma GCC diagnostic pop
 
 namespace slimt {

--- a/slimt/XHScanner.cc
+++ b/slimt/XHScanner.cc
@@ -5,6 +5,7 @@
 
 #include <cctype>
 #include <cstring>
+#include <string_view>
 
 namespace {
 
@@ -76,6 +77,8 @@ Scanner::TokenType Scanner::scan_body() {
       return scan_tag();
     case '&':
       return scan_entity(TT_TEXT);
+    default:
+      break;
   }
 
   while (true) {
@@ -144,6 +147,8 @@ Scanner::TokenType Scanner::scan_attribute() {
       } else {  // NOLINT
         return TT_ERROR;
       }
+    default:
+      break;
   }
 
   attribute_ = StringRef{input_.pos(), 0};

--- a/slimt/qmm/Gemmology.inl.cc
+++ b/slimt/qmm/Gemmology.inl.cc
@@ -1,3 +1,8 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include "gemmology/gemmology.h"
+#pragma GCC diagnostic pop
+
 #if defined(USE_AVX512)
 #define GEMMOLOGY_SUPPORTED_ARCHS \
   xsimd::arch_list<xsimd::avx512bw, xsimd::avx2, xsimd::ssse3, xsimd::sse2>

--- a/slimt/qmm/Intgemm.inl.cc
+++ b/slimt/qmm/Intgemm.inl.cc
@@ -1,3 +1,8 @@
+
+#include "intgemm/intgemm.h"
+
+#include "intgemm/callbacks/configs.h"
+
 namespace slimt::qmm::detail {
 template <>
 Tensor affine_with_select<Provider::Intgemm>(

--- a/slimt/qmm/Ruy.inl.cc
+++ b/slimt/qmm/Ruy.inl.cc
@@ -1,3 +1,4 @@
+#include "ruy/ruy.h"
 
 namespace slimt::qmm::detail {
 


### PR DESCRIPTION
Fix broken CI due to actions-runner. Manually install llvm-17 and make it preferred. The upgrade improves static analysis, leading to the following fixes, uniformities:

  - misc-include-cleaner: Add missing headers, remove unused headers
  - Use `\n` instead of `std::endl`
  - Move includes to included impl files
  - Fixes to HTML.cc
  - Add explicit `default: break` for switches
  - Fix use-after-free