### PR TITLE
Remove `mfpu=neon` from flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,6 @@ endif(USE_SSSE3)
 
 if(USE_NEON)
   list(APPEND SLIMT_COMPILE_DEFINITIONS USE_NEON)
-  list(APPEND SLIMT_QMM_COMPILE_OPTIONS -mfpu=neon)
 endif(USE_NEON)
 
 # cmake-format: off


### PR DESCRIPTION
Fixing build issue in mac os.

Command used to run for building in mac os
CMAKE_ARGS="-DUSE_NEON=ON" python3 setup.py bdist_wheel
