### PR TITLE
Add wheel upload infrastructure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,21 +295,25 @@ jobs:
     name: "Release Latest Build"
     runs-on: ubuntu-latest
     needs: [build-wheels]
+    permissions:
+      contents: "write"
+      packages: "write"
+      pull-requests: "read"
     steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@v2
+     - name: Download artifacts
+       uses: actions/download-artifact@v2
 
-    # Leave the below be, it will be useful.
-    - name: List downloaded assets
-      run: |
-       find ./
+     # Leave the below be, it will be useful.
+     - name: List downloaded assets
+       run: |
+        find ./
 
-    - name: Update GitHub prerelease
-      uses: marvinpinto/action-automatic-releases@latest
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        automatic_release_tag: latest
-        prerelease: true
-        title: "Latest Build"
-        files: |
-             wheels/*.whl
+     - name: Update GitHub prerelease
+       uses: marvinpinto/action-automatic-releases@latest
+       with:
+         repo_token: ${{ secrets.GITHUB_TOKEN }}
+         automatic_release_tag: latest
+         prerelease: true
+         title: "Latest Build"
+         files: |
+              wheels/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,7 +267,7 @@ jobs:
               ${{github.workspace}}\ccache.exe -z # Print current cache stats
 
 
-            CIBW_BUILD: "cp{37,38}-*manylinux_x86_64"
+            CIBW_BUILD: "cp{37,38,39,310,311}-*manylinux_x86_64 cp{37,38,39,310,311}-macosx_x86_64 cp3{8,9,10}-win_amd64 cp*macosx_arm64"
 
             CIBW_BEFORE_TEST_LINUX: |
               ccache -s # Print current ccache stats
@@ -315,5 +315,34 @@ jobs:
          automatic_release_tag: latest
          prerelease: true
          title: "Latest Build"
+         files: |
+              wheels/*.whl
+
+  release-version:
+    name: Release version
+    runs-on: ubuntu-latest
+    needs: [build-wheels, build-wasm]
+    permissions:
+      contents: "write"
+      packages: "write"
+      pull-requests: "read"
+
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+     - name: Download artifacts
+       uses: actions/download-artifact@v2
+
+     # Leave the below be, it will be useful.
+     - name: List downloaded assets
+       run: |
+         find ./
+
+     - name: Update GitHub release
+       uses: marvinpinto/action-automatic-releases@latest
+       with:
+         repo_token: ${{ secrets.GITHUB_TOKEN }}
+         automatic_release_tag: ${{ github.ref_name }}
+         prerelease: false
+         title: "${{ github.ref_name }}"
          files: |
               wheels/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -289,8 +289,8 @@ jobs:
           with:
             name: wheels
             path: ./wheelhouse/*.whl
-  upload-wheels:
-    name: "Upload wheels to PyPI"
+  upload-release:
+    name: "Upload Release"
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs: [build-wheels]
@@ -300,10 +300,25 @@ jobs:
       with:
         name: wheels
 
-    - name: Publish wheels to PyPI
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python3 -m pip install twine
-        twine upload *.whl
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Assets
+      id: upload-release-assets
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./wheelhouse/*.whl
+        asset_name: wheel
+        asset_content_type: application/zip
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -293,7 +293,7 @@ jobs:
   release-latest:
     name: Release Latest Build
     runs-on: ubuntu-latest
-    needs: [build-wheels, build-wasm]
+    needs: [build-wheels]
     if: github.ref == 'refs/heads/dev'
     steps:
      - name: Download artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -346,3 +346,24 @@ jobs:
          title: "${{ github.ref_name }}"
          files: |
               wheels/*.whl
+
+
+
+  upload-wheels:
+    name: "Upload wheels to PyPI"
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: [build-wheels]
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: wheels
+
+    - name: Publish wheels to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python3 -m pip install twine
+        twine upload *.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,7 +321,7 @@ jobs:
   release-version:
     name: Release version
     runs-on: ubuntu-latest
-    needs: [build-wheels, build-wasm]
+    needs: [build-wheels]
     permissions:
       contents: "write"
       packages: "write"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -304,12 +304,12 @@ jobs:
       run: |
        find ./
 
-   - name: Update GitHub prerelease
-     uses: marvinpinto/action-automatic-releases@latest
-     with:
-       repo_token: ${{ secrets.GITHUB_TOKEN }}
-       automatic_release_tag: latest
-       prerelease: true
-       title: "Latest Build"
-       files: |
-            wheels/*.whl
+    - name: Update GitHub prerelease
+      uses: marvinpinto/action-automatic-releases@latest
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        automatic_release_tag: latest
+        prerelease: true
+        title: "Latest Build"
+        files: |
+             wheels/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -305,19 +305,12 @@ jobs:
       run: |
        find ./
 
-    - name: Update GitHub prerelease
-      uses: actions/create-release@v1
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: true
-        prerelease: true
-
-    - name: Upload Release Assets
-      id: upload-release-assets
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./wheelhouse/*.whl
-        asset_name: wheel
-        asset_content_type: application/zip
+   - name: Update GitHub prerelease
+     uses: marvinpinto/action-automatic-releases@latest
+     with:
+       repo_token: ${{ secrets.GITHUB_TOKEN }}
+       automatic_release_tag: latest
+       prerelease: true
+       title: "Latest Build"
+       files: |
+            wheels/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -308,16 +308,16 @@ jobs:
     - name: Update GitHub prerelease
       uses: actions/create-release@v1
       with:
-      tag_name: ${{ github.ref }}
-      release_name: Release ${{ github.ref }}
-      draft: true
-      prerelease: true
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: true
+        prerelease: true
 
     - name: Upload Release Assets
       id: upload-release-assets
       uses: actions/upload-release-asset@v1
       with:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      asset_path: ./wheelhouse/*.whl
-      asset_name: wheel
-      asset_content_type: application/zip
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./wheelhouse/*.whl
+        asset_name: wheel
+        asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,7 +267,7 @@ jobs:
               ${{github.workspace}}\ccache.exe -z # Print current cache stats
 
 
-            CIBW_BUILD: "cp{37,38,39,310,311}-*manylinux_x86_64 cp{37,38,39,310,311}-macosx_x86_64 cp3{8,9,10}-win_amd64 cp*macosx_arm64"
+            CIBW_BUILD: "cp{37,38}-*manylinux_x86_64"
 
             CIBW_BEFORE_TEST_LINUX: |
               ccache -s # Print current ccache stats
@@ -303,8 +303,6 @@ jobs:
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
         release_name: Release ${{ github.ref }}
@@ -320,8 +318,6 @@ jobs:
     - name: Upload Release Assets
       id: upload-release-assets
       uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./wheelhouse/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,7 +295,6 @@ jobs:
     name: "Release Latest Build"
     runs-on: ubuntu-latest
     needs: [build-wheels]
-    if: ${{ github.ref_name == 'release' }}
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,6 +310,12 @@ jobs:
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: false
+        
+    - name: Debug Information
+      run: |
+        echo "Release Upload URL: ${{ steps.create_release.outputs.upload_url }}"
+        ls -R ./wheelhouse
+      working-directory: .
 
     - name: Upload Release Assets
       id: upload-release-assets

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,7 +295,7 @@ jobs:
     name: "Release Latest Build"
     runs-on: ubuntu-latest
     needs: [build-wheels]
-    if: github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/release'
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,35 +290,34 @@ jobs:
             name: wheels
             path: ./wheelhouse/*.whl
 
+
   release-latest:
-    name: Release Latest Build
+    name: "Release Latest Build"
     runs-on: ubuntu-latest
     needs: [build-wheels]
     if: github.ref == 'refs/heads/dev'
     steps:
-     - name: Download artifacts
-       uses: actions/download-artifact@v2
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
 
-     # Leave the below be, it will be useful.
-     - name: List downloaded assets
-       run: |
-         find ./
+    # Leave the below be, it will be useful.
+    - name: List downloaded assets
+      run: |
+       find ./
 
-     - name: Update GitHub prerelease
-       uses: actions/create-release@v1
-       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: true
-        prerelease: true
+    - name: Update GitHub prerelease
+      uses: actions/create-release@v1
+      with:
+      tag_name: ${{ github.ref }}
+      release_name: Release ${{ github.ref }}
+      draft: true
+      prerelease: true
 
     - name: Upload Release Assets
       id: upload-release-assets
       uses: actions/upload-release-asset@v1
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./wheelhouse/*.whl
-        asset_name: wheel
-        asset_content_type: application/zip
-
-
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      asset_path: ./wheelhouse/*.whl
+      asset_name: wheel
+      asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -299,6 +299,7 @@ jobs:
       contents: "write"
       packages: "write"
       pull-requests: "read"
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
      - name: Download artifacts
        uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -289,31 +289,28 @@ jobs:
           with:
             name: wheels
             path: ./wheelhouse/*.whl
-  upload-release:
-    name: "Upload Release"
-    runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    needs: [build-wheels]
-    steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: wheels
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      with:
+  release-latest:
+    name: Release Latest Build
+    runs-on: ubuntu-latest
+    needs: [build-wheels, build-wasm]
+    if: github.ref == 'refs/heads/dev'
+    steps:
+     - name: Download artifacts
+       uses: actions/download-artifact@v2
+
+     # Leave the below be, it will be useful.
+     - name: List downloaded assets
+       run: |
+         find ./
+
+     - name: Update GitHub prerelease
+       uses: actions/create-release@v1
+       with:
         tag_name: ${{ github.ref }}
         release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-        
-    - name: Debug Information
-      run: |
-        echo "Release Upload URL: ${{ steps.create_release.outputs.upload_url }}"
-        ls -R ./wheelhouse
-      working-directory: .
+        draft: true
+        prerelease: true
 
     - name: Upload Release Assets
       id: upload-release-assets
@@ -323,4 +320,5 @@ jobs:
         asset_path: ./wheelhouse/*.whl
         asset_name: wheel
         asset_content_type: application/zip
+
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,7 +295,7 @@ jobs:
     name: "Release Latest Build"
     runs-on: ubuntu-latest
     needs: [build-wheels]
-    if: github.ref == 'refs/heads/release'
+    if: ${{ github.ref_name == 'release' }}
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v2


### PR DESCRIPTION
- [ ] Release latest, upload wheels to GitHub
- [ ] Push self-contained wheels (with required `so` etc to PyPI). 
- [ ] Upload wheels on version tags to GitHub. Also need coordinated updates to the version file in [slimt.version](./slimt.version)


Debian requires the `.so` from `libslimt` installs to be used by the Python wheel (in case packaging for `python3-slimt` happens). Might be worthwhile to cover that here as well.