### PR TITLE
Provide preset configs in library

### DIFF
--- a/bindings/python/slimt.cpp
+++ b/bindings/python/slimt.cpp
@@ -208,7 +208,7 @@ PYBIND11_MODULE(_slimt, m) {
              return std::make_shared<Model>(config, package);
            }),
            py::arg("config"), py::arg("package"));
-           :
+
   auto sm_preset = m.def_submodule("preset");
   sm_preset.def("tiny11", preset::tiny11);
   sm_preset.def("base", preset::base);

--- a/bindings/python/slimt.cpp
+++ b/bindings/python/slimt.cpp
@@ -124,15 +124,7 @@ class PyService {
 
  private:
   static Service make_service(size_t workers, size_t cache_size) {
-    py::scoped_ostream_redirect outstream(
-        std::cout,                                 // std::ostream&
-        py::module_::import("sys").attr("stdout")  // Python output
-    );
-    py::scoped_ostream_redirect errstream(
-        std::cerr,                                 // std::ostream&
-        py::module_::import("sys").attr("stderr")  // Python output
-    );
-
+    Redirect redirect;
     py::call_guard<py::gil_scoped_release> gil_guard;
 
     ServiceConfig config;
@@ -216,4 +208,8 @@ PYBIND11_MODULE(_slimt, m) {
              return std::make_shared<Model>(config, package);
            }),
            py::arg("config"), py::arg("package"));
+           :
+  auto sm_preset = m.def_submodule("preset");
+  sm_preset.def("tiny11", preset::tiny11);
+  sm_preset.def("base", preset::base);
 }

--- a/bindings/python/slimt.cpp
+++ b/bindings/python/slimt.cpp
@@ -210,6 +210,6 @@ PYBIND11_MODULE(_slimt, m) {
            py::arg("config"), py::arg("package"));
 
   auto sm_preset = m.def_submodule("preset");
-  sm_preset.def("tiny11", preset::tiny11);
-  sm_preset.def("base", preset::base);
+  sm_preset.def("tiny11", slimt::preset::tiny11);
+  sm_preset.def("base", slimt::preset::base);
 }

--- a/bindings/python/slimt.cpp
+++ b/bindings/python/slimt.cpp
@@ -215,6 +215,6 @@ PYBIND11_MODULE(_slimt, m) {
            py::arg("config"), py::arg("package"));
 
   auto sm_preset = m.def_submodule("preset");
-  sm_preset.def("tiny11", slimt::preset::tiny11);
+  sm_preset.def("tiny", slimt::preset::tiny);
   sm_preset.def("base", slimt::preset::base);
 }

--- a/bindings/python/slimt.cpp
+++ b/bindings/python/slimt.cpp
@@ -193,7 +193,12 @@ PYBIND11_MODULE(_slimt, m) {
       .def_readwrite("vocabulary", &Package::vocabulary)
       .def_readwrite("shortlist", &Package::shortlist);
 
-  py::class_<ModelConfig>(m, "Config").def(py::init<>());
+  py::class_<ModelConfig>(m, "Config").def(py::init<>())
+      .def_readwrite("encoder_layers", &ModelConfig::encoder_layers)
+      .def_readwrite("decoder_layers", &ModelConfig::decoder_layers)
+      .def_readwrite("feed_forward_depth", &ModelConfig::feed_forward_depth)
+      .def_readwrite("num_heads", &ModelConfig::num_heads)
+      .def_readwrite("split_mode", &ModelConfig::split_mode);
 
   py::class_<PyService>(m, "Service")
       .def(py::init<size_t, size_t>(), py::arg("workers") = 1,

--- a/bindings/python/tests/test_ende_borked_base.py
+++ b/bindings/python/tests/test_ende_borked_base.py
@@ -1,0 +1,31 @@
+# type: ignore
+import os
+from slimt.utils import toJSON
+from slimt import REPOSITORY, Package, Model, preset
+import yaml
+
+
+def test_ende_borked_base(service, models, sample):
+    model_id = "en-de-base"
+    repository = "browsermt"
+    REPOSITORY.download(repository, model_id)
+    config_path = REPOSITORY.modelConfigPath(repository, model_id)
+    c = None
+    with open(config_path) as yaml_file:
+        c = yaml.safe_load(yaml_file)
+
+    root = os.path.dirname(config_path)
+    package = Package(
+        model=os.path.join(root, c["models"][0]),
+        vocabulary=os.path.join(root, c["vocabs"][0]),
+        shortlist=os.path.join(root, c["shortlist"][0]),
+    )
+
+    config = preset.base()
+    config.decoder_layers = 1
+    model = Model(config, package)
+
+    source, _, html = sample
+    responses = service.translate(model, [source], html=html)
+    for response in responses:
+        print(toJSON(response, indent=4))

--- a/slimt/Model.cc
+++ b/slimt/Model.cc
@@ -179,7 +179,7 @@ Histories Model::forward(const Input &input) const {
 }
 
 namespace preset {
-Model::Config tiny11() {
+Model::Config tiny() {
   // NOLINTBEGIN
   Model::Config config{
       .encoder_layers = 6,      //

--- a/slimt/Model.cc
+++ b/slimt/Model.cc
@@ -71,9 +71,9 @@ Model::Model(const Config &config, const Package<std::string> &package)
 
 namespace {
 void update_alignment(const std::vector<size_t> &lengths,
-                      const std::vector<bool> &finished, Tensor &attn,
+                      const std::vector<bool> &finished, const Tensor &attn,
                       Alignments &alignments) {
-  auto *data = attn.data<float>();
+  const auto *data = attn.data<float>();
   // B x H x 1 (T) x S
   size_t batch_size = attn.dim(-4);
   size_t num_heads = attn.dim(-3);
@@ -87,7 +87,7 @@ void update_alignment(const std::vector<size_t> &lengths,
     if (!finished[id]) {
       size_t batch_stride = (num_heads * slice * source_length);
       size_t head_stride = (slice * source_length);
-      float *alignment = data + id * batch_stride + head_id * head_stride;
+      const float *alignment = data + id * batch_stride + head_id * head_stride;
       size_t length = lengths[id];
       Distribution distribution(length);
       std::copy(alignment, alignment + length, distribution.data());

--- a/slimt/Model.cc
+++ b/slimt/Model.cc
@@ -177,4 +177,33 @@ Histories Model::forward(const Input &input) const {
   Histories histories = decode(encoder_out, input);
   return histories;
 }
+
+namespace preset {
+Model::Config tiny11() {
+  // NOLINTBEGIN
+  Model::Config config{
+      .encoder_layers = 6,      //
+      .decoder_layers = 2,      //
+      .feed_forward_depth = 2,  //
+      .num_heads = 8,           //
+      .split_mode = "sentence"  //
+  };
+  // NOLINTEND
+  return config;
+}
+
+Model::Config base() {
+  // NOLINTBEGIN
+  Model::Config config{
+      .encoder_layers = 6,      //
+      .decoder_layers = 2,      //
+      .feed_forward_depth = 2,  //
+      .num_heads = 8,           //
+      .split_mode = "sentence"  //
+  };
+  // NOLINTEND
+  return config;
+}
+}  // namespace preset
+
 }  // namespace slimt

--- a/slimt/Model.hh
+++ b/slimt/Model.hh
@@ -80,7 +80,7 @@ class SLIMT_EXPORT Model {
 };
 
 namespace preset {
-Model::Config tiny11();
+Model::Config tiny();
 Model::Config base();
 }  // namespace preset
 

--- a/slimt/Model.hh
+++ b/slimt/Model.hh
@@ -28,7 +28,6 @@ struct Package {
   Field ssplit;
 };
 
-
 class SLIMT_EXPORT Model {
  public:
   struct SLIMT_EXPORT Config {
@@ -81,8 +80,8 @@ class SLIMT_EXPORT Model {
 };
 
 namespace preset {
-  Model::Config tiny11();
-  Model::Config base();
-}
+Model::Config tiny11();
+Model::Config base();
+}  // namespace preset
 
 }  // namespace slimt

--- a/slimt/Model.hh
+++ b/slimt/Model.hh
@@ -28,6 +28,7 @@ struct Package {
   Field ssplit;
 };
 
+
 class SLIMT_EXPORT Model {
  public:
   struct SLIMT_EXPORT Config {
@@ -78,5 +79,10 @@ class SLIMT_EXPORT Model {
   Transformer transformer_;
   ShortlistGenerator shortlist_generator_;
 };
+
+namespace preset {
+  Model::Config tiny11();
+  Model::Config base();
+}
 
 }  // namespace slimt

--- a/slimt/Transformer.cc
+++ b/slimt/Transformer.cc
@@ -157,7 +157,7 @@ std::tuple<Tensor, Tensor> Decoder::step(const Tensor &encoder_out,
   auto [x, attn] =
       decoder_[0].forward(encoder_out, mask, states[0], decoder_embed);
 
-  Tensor guided_alignment;
+  Tensor guided_alignment = std::move(attn);
   for (size_t i = 1; i < decoder_.size(); i++) {
     auto [y, _attn] = decoder_[i].forward(encoder_out, mask, states[i], x);
     x = std::move(y);


### PR DESCRIPTION
Currently, the Python calling code looks like:

```py
config = Config()
model = Model(config, package)
```

This is not informative or self-contained enough of the intentions. This PR tries to change this to:

```py
tiny: Config = slimt.preset.tiny()
model = Model(tiny, package)

base: Config = slimt.preset.base()
model = Model(base, package)
```

It's mostly cosmetic, with now the ability to indicate whether we're using a `tiny` configuration or a `base` configuration. This may also allow getting the borked `deen` base model to work. The data-members on `Config` are exposed for read-write via python.

<details> <summary> Broken <code>en-de-base</code> </summary>

```
$ slimt translate -m en-de-base <<< "Hello world"
[warn] Failed to ingest expected load of Wemb_QuantMultA
[warn] Failed to ingest expected load of special:model.yml
[warn] Failed to complete expected load of decoder_l2_ffn_ffn_ln_bias
[warn] Failed to complete expected load of decoder_l2_rnn_ffn_ln_scale
[warn] Failed to complete expected load of decoder_l2_ffn_b2
[warn] Failed to complete expected load of decoder_l2_ffn_W2
[warn] Failed to complete expected load of decoder_l2_ffn_b1
[warn] Failed to complete expected load of decoder_l2_context_bo
[warn] Failed to complete expected load of decoder_l2_context_Wv_QuantMultA
[warn] Failed to complete expected load of decoder_l2_context_Wk_QuantMultA
[warn] Failed to complete expected load of decoder_l2_ffn_ffn_ln_scale
[warn] Failed to complete expected load of decoder_l2_context_Wk
[warn] Failed to complete expected load of decoder_l2_context_Wq_QuantMultA
[warn] Failed to complete expected load of decoder_l2_context_bq
[warn] Failed to complete expected load of decoder_l2_context_Wq
[warn] Failed to complete expected load of decoder_l2_context_Wo_QuantMultA
[warn] Failed to complete expected load of decoder_l2_context_Wo
[warn] Failed to complete expected load of decoder_l2_context_Wo_ln_scale
[warn] Failed to complete expected load of decoder_l2_ffn_W2_QuantMultA
[warn] Failed to complete expected load of decoder_l2_rnn_bf
[warn] Failed to complete expected load of decoder_l2_rnn_Wf
[warn] Failed to complete expected load of decoder_l2_context_bv
[warn] Failed to complete expected load of decoder_l2_rnn_W_QuantMultA
[warn] Failed to complete expected load of decoder_l2_rnn_ffn_ln_bias
[warn] Failed to complete expected load of decoder_l2_rnn_W
[warn] Failed to complete expected load of decoder_l2_ffn_W1_QuantMultA
[warn] Failed to complete expected load of decoder_l2_context_bk
[warn] Failed to complete expected load of decoder_l2_context_Wo_ln_bias
[warn] Failed to complete expected load of decoder_l2_context_Wv
[warn] Failed to complete expected load of decoder_l2_ffn_W1
[warn] Failed to complete expected load of decoder_l2_rnn_Wf_QuantMultA
```
</details>

Will probably need to figure out what is happening with the model, it does not work still - but at least the configurability is a net plus.