### PR TITLE
Remove `automatic_release_tag` for version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -342,7 +342,6 @@ jobs:
        uses: marvinpinto/action-automatic-releases@latest
        with:
          repo_token: ${{ secrets.GITHUB_TOKEN }}
-         automatic_release_tag: ${{ github.ref_name }}
          prerelease: false
          title: "${{ github.ref_name }}"
          files: |


### PR DESCRIPTION
The action for versions is failing due to the additional tag mention: https://github.com/jerinphilip/slimt/actions/runs/7438858867/job/20238598711

This is meant to fix, but fingers crossed.